### PR TITLE
Remove max-width property for .markdown-body class

### DIFF
--- a/jekyll-stuff/css/style.css
+++ b/jekyll-stuff/css/style.css
@@ -22,7 +22,6 @@ table th {text-align: center; background-color: #ddd;}
 .markdown-body {
   box-sizing: border-box;
   min-width: 200px;
-  max-width: 980px;
   margin: 0 auto;
   padding: 45px;
 }


### PR DESCRIPTION
Better fit for wide screens
